### PR TITLE
Correction for links to SpaceFed

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -54,15 +54,15 @@
       "type": "object",
       "properties": {
         "spacenet": {
-          "description": "See the <a target=\"_blank\" href=\"https://spacefed.net/wiki/index.php/Category:Howto/Spacenet\">wiki</a>.",
+          "description": "See the <a target=\"_blank\" href=\"https://spacefed.net/index.php/Category:Howto/Spacenet\">wiki</a>.",
           "type": "boolean"
         },
         "spacesaml": {
-          "description": "See the <a target=\"_blank\" href=\"https://spacefed.net/wiki/index.php/Category:Howto/Spacesaml\">wiki</a>.",
+          "description": "See the <a target=\"_blank\" href=\"https://spacefed.net/index.php/Category:Howto/Spacenet\">wiki</a>.",
           "type": "boolean"
         },
         "spacephone": {
-          "description": "See the <a target=\"_blank\" href=\"https://spacefed.net/wiki/index.php/Category:Howto/Spacephone\">wiki</a>.",
+          "description": "See the <a target=\"_blank\" href=\"https://spacefed.net/index.php/Category:Howto/Spacenet\">wiki</a>.",
           "type": "boolean"
         }
       },


### PR DESCRIPTION
Wiki links on SpaceFed have changed.
prior wrong link:
https://spacefed.net/wiki/index.php/Category:Howto/Spacenet
new working link:
https://spacefed.net/index.php/Category:Howto/Spacenet

This commit adjusts only these links to correct destination.
Should this be applied similaryly to older versions of space api json schema is not in my decision.